### PR TITLE
Add remove-audio.com — free browser-based video audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+- - [Remove Audio](https://remove-audio.com) — Free, browser-based audio remover for video files. Uses WebAssembly for local processing — no uploads needed. Supports batch mode for up to 20 clips.
 # Awesome Audiovisual [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 > Curated list of software, libraries and resources for lighting, video and audio professionals and hobbyists.
@@ -86,6 +87,7 @@ See [ebu/awesome-broadcasting](https://github.com/ebu/awesome-broadcasting#readm
 
 - [Livescript](https://github.com/Netlob/livescript) - Insert a musical/theatre-script from Google Docs and use this for a live "autocue" and scroller with everyone on the site. `✓ open-source`.
 - [Ontime](https://github.com/cpvalente/ontime) - Browser-based application that manages event rundowns, scheduling, and cueing. Plan, track your schedule, manage automation and cross-department show information in one place. `✓ open-source`.
+- [Remove Audio](https://remove-audio.com) — Free, browser-based audio remover for video files. Uses WebAssembly for local processing, no uploads needed. Supports batch mode for up to 20 clips.
 - [RunCue](https://runcue.fly.dev/) - `⚠ not free` Browser-based timer for webinar producers with separate control, speaker, and audience links plus private cues.
 - [stagetimer.io](https://stagetimer.io) - Browser-based remote-controlled countdown timer.  `⚠ freemium`.
 


### PR DESCRIPTION
remove-audio.com removes audio from video files entirely in the browser using WebAssembly and FFmpeg.wasm. No server uploads, no account required, no watermarks. Supports batch processing up to 20 files. Free and works on mobile. Fits the Tools section of this list.