### PR TITLE
Add RunCue to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ See [ebu/awesome-broadcasting](https://github.com/ebu/awesome-broadcasting#readm
 
 - [Livescript](https://github.com/Netlob/livescript) - Insert a musical/theatre-script from Google Docs and use this for a live "autocue" and scroller with everyone on the site. `✓ open-source`.
 - [Ontime](https://github.com/cpvalente/ontime) - Browser-based application that manages event rundowns, scheduling, and cueing. Plan, track your schedule, manage automation and cross-department show information in one place. `✓ open-source`.
+- [RunCue](https://runcue.fly.dev/) - `⚠ not free` Browser-based timer for webinar producers with separate control, speaker, and audience links plus private cues.
 - [stagetimer.io](https://stagetimer.io) - Browser-based remote-controlled countdown timer.  `⚠ freemium`.
 
 ### CADs


### PR DESCRIPTION
## What changed

- Added RunCue to the existing **Tools** section, alphabetically between Ontime and stagetimer.io.
- Described the shipped browser timer workflow in one line.
- Marked it `⚠ not free` because RunCue offers a 15-minute trial but no free tier.

## Why

RunCue is an actively maintained browser-based timer for webinar production, with separate control, speaker, and audience links plus private producer cues. It fits the same audiovisual tools category as the existing Ontime and stagetimer.io entries.

## Validation

- [x] One project link and a description under 250 characters
- [x] Alphabetical placement
- [x] Correct paid-product marker
- [x] Tracked product URL returns HTTP 200
- [x] `git diff --check` passes

`awesome-lint` reports the repository's existing lint findings; none identifies the added RunCue line.
